### PR TITLE
Enable creating acb with inputs of two different datatypes (#934)

### DIFF
--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1821,10 +1821,42 @@ end
 
 (r::AcbField)(x::Rational{T}) where {T <: Integer} = r(fmpq(x))
 
-function (r::AcbField)(x::T, y::T) where {T <: Union{Int, UInt,fmpz, fmpq, arb, Float64, BigFloat, AbstractString}}
+function (r::AcbField)(x::T, y::T) where {T <: Union{Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString}}
   z = acb(x, y, r.prec)
   z.parent = r
   return z
+end
+
+for S in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
+  for T in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
+    if S != T
+      @eval begin
+        function (r::AcbField)(x::$(S), y::$(T))
+          RR = ArbField(r.prec, cached = false)
+          z = acb(RR(x), RR(y), r.prec)
+          z.parent = r
+          return z
+        end
+      end
+    end
+  end
+end
+
+for T in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
+  @eval begin
+    function (r::AcbField)(x::Rational{S}, y::$(T)) where {S <: Integer}
+      RR = ArbField(r.prec, cached = false)
+      z = acb(RR(x), RR(y), r.prec)
+      z.parent = r
+      return z
+    end
+    function (r::AcbField)(x::$(T), y::Rational{S}) where {S <: Integer}
+      RR = ArbField(r.prec, cached = false)
+      z = acb(RR(x), RR(y), r.prec)
+      z.parent = r
+      return z
+    end
+  end
 end
 
 (r::AcbField)(x::BigInt, y::BigInt) = r(fmpz(x), fmpz(y))

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -52,6 +52,11 @@ end
    @test real(b) == 2
    @test imag(b) == 3
 
+   @test CC(UInt(4), Int(2)) == CC(4.0, ZZ(2))
+   @test CC("4 +/- 0", BigFloat(2)) == CC(RR(4), QQ(2))
+   @test CC(UInt(8)//UInt(2), BigInt(2)) == CC(4, 2)
+@test CC(2, UInt(8)//UInt(2)) == CC(2, 4)
+
    @test characteristic(CC) == 0
 end
 


### PR DESCRIPTION
* Add spacing between types

* Enable calling acb with inputs of two different datatypes

* Add BigInt, Rational{Integer} to non-equal types when calling ArbField

* Add test for ArbField-method with arguments of two non-equal types

Co-authored-by: thofma <thofma@gmail.com>